### PR TITLE
Fixed problem with saving temporary figures on windows.

### DIFF
--- a/src/utils/plots.jl
+++ b/src/utils/plots.jl
@@ -877,13 +877,23 @@ function save_figure(
         tight_layout_applied = false # reset
     else
         filename = split(filename, "/")[end] # Get just the name
-        plt.savefig(
-            @sprintf("/tmp/%s", filename),
-            bbox_inches = "tight",
-            pad_inches = 0.01,
-            facecolor = facecolor,
-            dpi = dpi,
-        )
+        if Sys.iswindows()
+             plt.savefig(
+                "C:\\Users\\" * ENV["USERNAME"] * "\\AppData\\Local\\Temp\\" * filename,
+                bbox_inches = "tight",
+                pad_inches = 0.01,
+                facecolor = facecolor,
+                dpi = dpi,
+            )
+        else
+            plt.savefig(
+                @sprintf("/tmp/%s", filename),
+                bbox_inches = "tight",
+                pad_inches = 0.01,
+                facecolor = facecolor,
+                dpi = dpi,
+            )
+        end
     end
 
     return nothing


### PR DESCRIPTION
/tmp directory doesn't exist on windows. This resulted in an error when running the SCPToolbox.jl tests. I added a fix that employs the Temp folder in a users directory (i.e., C:\\Users\\insert-users-name\\AppData\\Local\\Temp) which should exist for any user on any windows machine. 